### PR TITLE
Add optional email check

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ AppConfig[:authentication_sources] = [
         model: 'ASOauth',                                                                                                                                                           
         provider: 'cas',                                                                                                                                                            
         label: 'CAS Sign In',                                                                                                                                                        
-        config: {                                                                                                                                                                   
-          url: 'https://login.your.institution.edu',                                                                                                                                             
-          host: 'login.your.institution.edu',                                                                                                                                                    
+        config: {                                                              
+          url: 'https://login.ivory-tower.edu',                                                                                                                                             
+          host: 'login.ivory-tower.edu',                                                                                                                                                    
           ssl: true,                                                                                                                                                                
           login_url: '/cas/login',                                                                                                                                                  
           logout_url: '/cas/logout',                                                                                                                                                
           service_validate_url: '/cas/serviceValidate',                                                                                                                             
+          # if your server does not return an email address, you can add one
+          # here using the fetch_raw_info option. 
+          fetch_raw_info: ->(s, o, t, user_info) {  { email: "#{user_info['user']}@ivory-tower.edu" } } 
         }                                                                                                                                                                           
   }  
 ]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ AppConfig[:authentication_sources] = [
       :idp_cert_fingerprint_validator     => lambda { |fingerprint| fingerprint },
       :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
     },
+   {                                                                                                                                                                                 
+        model: 'ASOauth',                                                                                                                                                           
+        provider: 'cas',                                                                                                                                                            
+        label: 'CAS Sign In',                                                                                                                                                        
+        config: {                                                                                                                                                                   
+          url: 'https://login.your.institution.edu',                                                                                                                                             
+          host: 'login.your.institution.edu',                                                                                                                                                    
+          ssl: true,                                                                                                                                                                
+          login_url: '/cas/login',                                                                                                                                                  
+          logout_url: '/cas/logout',                                                                                                                                                
+          service_validate_url: '/cas/serviceValidate',                                                                                                                             
+        }                                                                                                                                                                           
+  }  
 ]
 
 # add the plugin to the list

--- a/backend/model/asoauth.rb
+++ b/backend/model/asoauth.rb
@@ -25,7 +25,10 @@ class ASOauth
     id_path = File.join(Dir.tmpdir, password)
     return nil unless File.exists? id_path
 
-    user = JSON.parse(File.read(id_path))["info"]
+    json = JSON.parse(File.read(id_path))
+    user = json["info"]
+    # if theres no email check the exta field
+    user["email"] ||= json["extra"]["email"]
     return nil unless username == user["email"].split('@')[0]
 
     user_data = {

--- a/frontend/controllers/oauth_controller.rb
+++ b/frontend/controllers/oauth_controller.rb
@@ -13,7 +13,11 @@ class OauthController < ApplicationController
     File.open(id_path, 'w') { |f| f.write(JSON.generate(auth_hash)) }
 
     # usernames cannot be email addresses
-    username = auth_hash[:info][:email].split('@')[0]
+    username = if auth_hash[:info].has_key?(:email)
+                 auth_hash[:info][:email].split('@')[0]
+              else
+                 auth_hash[:extra][:email].split('@')[0]
+              end
     backend_session = User.login(username, id)
 
     if backend_session


### PR DESCRIPTION
Some orgs don't return email addresses. Too political, i guess. 

Since the plug-in expects an email to build a username, we need to be sure that we're getting an email somehow. The CAS strategy allows to pass a lambda that adds data into the "extra" key. So, this checks the "info" for an email, then checks in "extra" if it doesn't exist. 

I guess some alternatives would be to use ["info"]["name"] ( which is required by omniauth ) to build the name or be able to configure how to build a username for each strategy. 
 