### PR TITLE
Support deployments with separate back/frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ArchivesSpace Oauth
 
 Configure ArchivesSpace as a service provider (SP) for oauth authentication.
-*The plugin delegates authentication to the configured identity provider (IDP).*
+_The plugin delegates authentication to the configured identity provider (IDP)._
 
 Strategies tested:
 
@@ -109,6 +109,14 @@ AppConfig[:authentication_sources] = [
 
 # add the plugin to the list
 AppConfig[:plugins] << "aspace-oauth"
+
+# Most people can ignore this. If the ArchivesSpace frontend and backend are
+# deployed separately (not the default), both frontend and backend need the same
+# value for :oauth_shared_secret in order to validate login requests between the
+# frontend and backend. Set this to a long password-like random value.
+# When not set, a value is generated automatically and shared inside the JVM
+# using a system property.
+#AppConfig[:oauth_shared_secret] = "00000000-0000-0000-0000-000000000000"
 ```
 
 Add / change providers as needed and refer to the project documentation

--- a/backend/model/asoauth.rb
+++ b/backend/model/asoauth.rb
@@ -3,6 +3,9 @@
 class ASOauthException < StandardError
 end
 
+class InvalidLoginTokenException < ASOauthException
+end
+
 class ASOauth
   include JSONModel
 
@@ -20,12 +23,13 @@ class ASOauth
   # filename is provided as the "password".
   # The file and contents are checked to verify the user.
   def authenticate(username, password)
-    return nil unless password.start_with?("aspace-oauth-#{@provider}")
+    begin
+      info = validate_login_token_and_extract_user_info(password)
+    rescue InvalidLoginTokenException => e
+      Log.warn("ASOauth: rejected authentication with invalid login token: #{e}")
+      return nil
+    end
 
-    pw_path = File.join(Dir.tmpdir, password)
-    return nil unless File.exist? pw_path
-
-    info = JSON.parse(File.read(pw_path))['info']
     return nil unless username == info['username'].downcase
 
     JSONModel(:user).from_hash(
@@ -37,6 +41,80 @@ class ASOauth
       telephone: info['phone'],
       additional_contact: info['description']
     )
+  end
+
+  def get_oauth_shared_secret
+    if AppConfig.has_key? :oauth_shared_secret
+      secret = AppConfig[:oauth_shared_secret]
+    else
+      # When a value for oauth_shared_secret isn't explicitly configured, the
+      # frontend generates a value which it saves in a JVM system property. When
+      # the frontend and backend are running in the same JVM (which is the
+      # default) we can pick up the generated value.
+      secret = java.lang.System.get_property("aspace.config.oauth_shared_secret")
+      unless secret.nil?
+        AppConfig[:oauth_shared_secret] = secret
+      end
+    end
+
+    unless secret.is_a? String and secret.length > 0
+      raise ASOauthException.new(":oauth_shared_secret config option is not set")
+    end
+    secret
+  end
+
+  def validate_login_token_and_extract_user_info(login_token)
+    begin
+      unverified_token = JSON.parse(login_token)
+    rescue JSON::ParserError => e
+      raise InvalidLoginTokenException.new("login_token is not valid JSON")
+    end
+
+    signature = unverified_token["signature"] if unverified_token.is_a? Hash
+    json_payload = unverified_token["payload"] if unverified_token.is_a? Hash
+
+    unless signature.is_a? String and json_payload.is_a? String
+      raise InvalidLoginTokenException.new("login_token content is invalid")
+      return nil
+    end
+
+    secret = get_oauth_shared_secret
+    expected_signature = OpenSSL::HMAC.hexdigest("SHA256", secret, json_payload)
+    unless Rack::Utils.secure_compare(expected_signature, signature)
+      raise InvalidLoginTokenException.new(
+        "login_token signature does not match the signature expected by our oauth_shared_secret"
+      )
+    end
+
+    begin
+      payload = JSON.parse(json_payload)
+    rescue JSON::ParserError => e
+      raise InvalidLoginTokenException.new("login_token payload is not valid JSON")
+    end
+
+    unless payload["created_by"] == "aspace-oauth-#{@provider}"
+      raise InvalidLoginTokenException.new("rejected login_token from unexpected provider")
+    end
+
+    begin
+      created_at = DateTime.rfc3339(payload["created_at"])
+    rescue ArgumentError
+      raise InvalidLoginTokenException.new("login_token's created_at is not a rfc3339 date-time")
+    end
+    delta_seconds = ((DateTime.now - created_at).abs * 24 * 60 * 60).to_f
+    unless delta_seconds <= 60
+      raise InvalidLoginTokenException.new(
+        "login_token's created_at is not within 60 seconds of current time"
+      )
+    end
+
+    user_info = payload["user_info"]
+    unless user_info.is_a? Hash and user_info.has_key? "username"
+      raise InvalidLoginTokenException.new(
+        "login_token's payload user_info is invalid"
+      )
+    end
+    user_info
   end
 
   def matching_usernames(query)

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -8,6 +8,19 @@ unless oauth_definitions.any?
   raise 'OmniAuth plugin enabled but no definitions provided =('
 end
 
+# oauth_shared_secret is used to authenticate internal login requests from the
+# frontend to the backend. It needs to be explicitly specified if the backend is
+# not running in the same JVM as the frontend. When they're in the same JVM the
+# secret generated here is propagated between them automatically via the system
+# property set here.
+if not AppConfig.has_key? :oauth_shared_secret
+  require 'securerandom'
+  AppConfig[:oauth_shared_secret] = SecureRandom.uuid
+  java.lang.System.set_property(
+    "aspace.config.oauth_shared_secret", AppConfig[:oauth_shared_secret]
+  )
+end
+
 # also used for ui [refactor]
 AppConfig[:oauth_definitions] = oauth_definitions
 ArchivesSpace::Application.extend_aspace_routes(


### PR DESCRIPTION
We use aspace-oauth in our ArchivesSpace deployment at Cambridge University. We deploy ArchivesSpace with each of the components in separate containers, so the frontend and backend don't share a `/tmp` filesystem. The plugin currently communicates auth requests between the frontend and backend by creating files in `/tmp`, so this plugin isn't compatible with multi-node deployments.

For our deployment, I modified the plugin to pass authentication info from frontend to backend using a signed token in the password field. This removes the need for components to share a filesystem.

For typical deployments where everything is in one JVM, the plugin generates a shared secret and stores it in a system property so that both frontend and backend can access it without any configuration. Multi-node deployments (like ours) need to explicitly configure a value for `AppConfig[:oauth_shared_secret]`, so that all nodes use the same value.

Would you be interested in this functionality? If not we can maintain a fork, but I figured it may be a useful feature for other people trying multi-node deployments.