### PR TITLE
Re-apply header_global template changes to latest version

### DIFF
--- a/frontend/views/shared/_header_global.html.erb
+++ b/frontend/views/shared/_header_global.html.erb
@@ -1,21 +1,12 @@
-<div class="container global-header">
+<div class="container-fluid global-header">
+  <span class="sr-only">
+    <h1>
+      <%= I18n.t("header.staff_interface") %>
+    </h1>
+  </span>
   <nav class="navbar">
-    <div class="container">
-
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".nav-global-collapse">
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-      </div>
-
-      <% if !session[:user] %>
-        <button type="button" class="btn btn-default pull-right btn-collapse-login navbar-btn" data-toggle="collapse" data-target=".nav-global-collapse">
-          <%= I18n.t("navbar.login") %>
-        </button>
-      <% end %>
-      <div class="navbar-collapse nav-global-collapse collapse navbar-right navbar-default">
+    <div class="container-fluid sm-mxn15px">
+      <div class="navbar-collapse nav-global-collapse navbar-right navbar-default">
         <ul class="nav pull-right navbar-nav navbar-login">
           <%= render "shared/header_user" %>
           <!-- PLUGIN BEGIN -->
@@ -26,7 +17,7 @@
           <% end %>
           <!-- PLUGIN END -->
           <% if ArchivesSpaceHelp.enabled? %>
-            <li><%= link_to_help :link_opts => {"data-placement" => (session[:user] ? "left" : "bottom")} %></li>
+            <li class="xs-py15px"><%= link_to_help %></li>
           <% end %>
         </ul>
       </div><!-- nav-collapse -->


### PR DESCRIPTION
The current `_header_global.html.erb` is forked from old version that has seen several changes. I've updated the template by adding the "PLUGIN BEGIN" sections into the most recent version of _header_global.

(I was just making some style changes to our theme, and noticed this plugin's header uses different markup/CSS classes to the current version.)

- Current base version seems to be: https://github.com/archivesspace/archivesspace/blob/9101b7dd6b8d90a297bf9cb7798d11273b9f186c/frontend/app/views/shared/_header_global.html.erb
- This version is based on: https://github.com/archivesspace/archivesspace/blob/fb84f71e5a4675db34bd1734a3826abb8d47b9ce/frontend/app/views/shared/_header_global.html.erb