### PR TITLE
Remove rexml from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,3 @@ gem 'omniauth',      '~> 1.7', '>= 1.7.1'
 gem 'omniauth-cas',  '~> 2.0'
 gem 'omniauth-saml', '~> 1.8', '>= 1.8.1'
 gem 'addressable',   '~> 2.8'
-
-# maintain compatibility with 3.5.0 as released
-gem 'rexml', '~> 3.2', '>= 3.2.5', '< 3.2.9'


### PR DESCRIPTION
Recent compatibility issues have been addressed from 3.3.0:

https://github.com/ruby/rexml/commit/31738ccfc3324f4b32769fa1695c78c06a88c277
