### PR TITLE
Allow for an alt config for SAML SLO

### DIFF
--- a/frontend/lib/aspace_oauth.rb
+++ b/frontend/lib/aspace_oauth.rb
@@ -43,14 +43,15 @@ module AspaceOauth
     AppConfig[:oauth_definitions].find { |oauth| oauth[:provider] == strategy }
   end
 
+
   def self.saml_logout_url
     config = get_oauth_config_for("saml")
     return unless config
-
+    
     host = config[:config][:idp_slo_service_url]
     
-    if config[:config][:idp_slo_service_url]
-      config[:config][:idp_slo_service_url].to_s
+    if host
+      host.to_s
     else
       build_url(
         AppConfig[:frontend_proxy_url],

--- a/frontend/lib/aspace_oauth.rb
+++ b/frontend/lib/aspace_oauth.rb
@@ -47,10 +47,16 @@ module AspaceOauth
     config = get_oauth_config_for("saml")
     return unless config
 
-    build_url(
-      AppConfig[:frontend_proxy_url],
-      "#{AppConfig[:frontend_proxy_prefix]}auth/saml/spslo"
-    )
+    host = config[:config][:idp_slo_service_url]
+    
+    if config[:config][:idp_slo_service_url]
+      config[:config][:idp_slo_service_url].to_s
+    else
+      build_url(
+        AppConfig[:frontend_proxy_url],
+        "#{AppConfig[:frontend_proxy_prefix]}auth/saml/spslo"
+      )
+    end
   end
 
   def self.use_uid?


### PR DESCRIPTION
This allows for an alternate config setting for SAML SLO, if the config value exists use this instead. We have a way to destroy sessions with a url and we did a custom override but no reason this couldn't go to core