### PR TITLE
fix cas logout dropdown link as it was off kilter by leveraging class…

### DIFF
--- a/frontend/views/shared/_header_global.html.erb
+++ b/frontend/views/shared/_header_global.html.erb
@@ -28,7 +28,7 @@
     <script type="text/javascript">
       (function() {
         var logout = $('a[href~="<%= AppConfig[:frontend_proxy_prefix] %>logout"]').parent().parent();
-        logout.append('<li><%= link_to("#{oauth_definition[:provider].upcase} Logout", "#{AppConfig[:frontend_proxy_prefix]}auth/#{oauth_definition[:provider]}_logout") %></li>');
+        logout.append('<li><%= link_to("#{oauth_definition[:provider].upcase} Logout", "#{AppConfig[:frontend_proxy_prefix]}auth/#{oauth_definition[:provider]}_logout", class: "dropdown-item") %></li>');
       })();
     </script>
   <% end %>


### PR DESCRIPTION
looks like upstream changes caused the cas logout link to be off kilter

found in archivesspace v4.1.1 using aspace-oauth v4.0.0