### PR TITLE
Option to Prevent New User Creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .bundle/
 Gemfile.lock
 vendor/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ config: {
 }
 ```
 
+## Prevent SSO User registration
+
+To prevent user registration for new users logging in with SSO, set
+```ruby
+AppConfig[:aspace_oauth_allow_sso_user_registration] = false
+```
+
 ## Developer
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ config: {
 }
 ```
 
-## Prevent SSO User registration
+## Prevent New User registration
 
 To prevent user registration for new users logging in with SSO, set
 ```ruby
-AppConfig[:aspace_oauth_allow_sso_user_registration] = false
+AppConfig[:oauth_allow_user_registration] = false
 ```
 
 ## Developer

--- a/backend/model/asoauth.rb
+++ b/backend/model/asoauth.rb
@@ -34,12 +34,14 @@ class ASOauth
 
     # Reject authentication if user does not already exist in the database
     # and new user registration is not allowed
-    if AppConfig.has_key?(:aspace_oauth_allow_sso_user_registration) && AppConfig[:aspace_oauth_allow_sso_user_registration] == false
+    if AppConfig.has_key?(:oauth_allow_user_registration) && AppConfig[:oauth_allow_user_registration] == false
       existing_user = DB.open do |db|
-        db[:user].filter(Sequel.function(:lower, :username) => username.downcase)
+        db[:user]
+          .where(Sequel.function(:lower, :username) => username.downcase)
+          .count > 0
       end
 
-      if existing_user.count == 0
+      unless existing_user
         Log.warn("ASOauth: rejected authentication for unknown user: #{username}")
         return nil
       end

--- a/backend/model/asoauth.rb
+++ b/backend/model/asoauth.rb
@@ -32,6 +32,19 @@ class ASOauth
 
     return nil unless username == info["username"].downcase
 
+    # Reject authentication if user does not already exist in the database
+    # and new user registration is not allowed
+    if AppConfig.has_key?(:aspace_oauth_allow_sso_user_registration) && AppConfig[:aspace_oauth_allow_sso_user_registration] == false
+      existing_user = DB.open do |db|
+        db[:user].filter(Sequel.function(:lower, :username) => username.downcase)
+      end
+
+      if existing_user.count == 0
+        Log.warn("ASOauth: rejected authentication for unknown user: #{username}")
+        return nil
+      end
+    end
+
     JSONModel(:user).from_hash(
       username: username,
       name: info["name"],

--- a/test/unit/asoauth_test.rb
+++ b/test/unit/asoauth_test.rb
@@ -29,6 +29,25 @@ module JSONModel
   end
 end
 
+# Mock DB module
+module DB
+  def self.open
+    yield self if block_given?
+  end
+end
+
+# Mock Sequel module
+module Sequel
+  def self.function(*args)
+    # Returns a placeholder that the stub dataset will ignore
+    :sequel_function
+  end
+
+  def self.~(*args)
+    :sequel_not
+  end
+end
+
 # Load the ASOauth model
 require_relative "../../backend/model/asoauth"
 
@@ -324,4 +343,43 @@ class ASOauthTest < Minitest::Test
 
     assert_nil result
   end
+
+  # Tests for AppConfig[:aspace_oauth_allow_sso_user_registration] behaviour
+  def test_authenticate_skips_db_check_when_registration_allowed
+    AppConfig[:aspace_oauth_allow_sso_user_registration] = true
+    oauth = ASOauth.new(provider: "saml")
+    token = generate_login_token(username: "newuser")
+
+    # DB.open must never be called when registration is allowed
+    DB.expects(:open).never
+
+    result = oauth.authenticate("newuser", token)
+
+    assert_equal "newuser", result[:username]
+  end
+
+  def test_authenticate_returns_nil_for_unknown_user_when_registration_disabled
+    AppConfig[:aspace_oauth_allow_sso_user_registration] = false
+    oauth = ASOauth.new(provider: "saml")
+    token = generate_login_token(username: "unknownuser")
+
+    DB.stubs(:[]).returns(stub(filter: stub(count: 0)))
+
+    result = oauth.authenticate("unknownuser", token)
+
+    assert_nil result
+  end
+
+  def test_authenticate_succeeds_for_known_user_when_registration_disabled
+    AppConfig[:aspace_oauth_allow_sso_user_registration] = false
+    oauth = ASOauth.new(provider: "saml")
+    token = generate_login_token(username: "existinguser")
+
+    DB.stubs(:[]).returns(stub(filter: stub(count: 1)))
+
+    result = oauth.authenticate("existinguser", token)
+
+    assert_equal "existinguser", result[:username]
+  end
+
 end

--- a/test/unit/asoauth_test.rb
+++ b/test/unit/asoauth_test.rb
@@ -344,9 +344,9 @@ class ASOauthTest < Minitest::Test
     assert_nil result
   end
 
-  # Tests for AppConfig[:aspace_oauth_allow_sso_user_registration] behaviour
+  # Tests for AppConfig[:oauth_allow_user_registration] behaviour
   def test_authenticate_skips_db_check_when_registration_allowed
-    AppConfig[:aspace_oauth_allow_sso_user_registration] = true
+    AppConfig[:oauth_allow_user_registration] = true
     oauth = ASOauth.new(provider: "saml")
     token = generate_login_token(username: "newuser")
 
@@ -359,11 +359,11 @@ class ASOauthTest < Minitest::Test
   end
 
   def test_authenticate_returns_nil_for_unknown_user_when_registration_disabled
-    AppConfig[:aspace_oauth_allow_sso_user_registration] = false
+    AppConfig[:oauth_allow_user_registration] = false
     oauth = ASOauth.new(provider: "saml")
     token = generate_login_token(username: "unknownuser")
 
-    DB.stubs(:[]).returns(stub(filter: stub(count: 0)))
+    DB.stubs(:[]).returns(stub(where: stub(count: 0)))
 
     result = oauth.authenticate("unknownuser", token)
 
@@ -371,11 +371,11 @@ class ASOauthTest < Minitest::Test
   end
 
   def test_authenticate_succeeds_for_known_user_when_registration_disabled
-    AppConfig[:aspace_oauth_allow_sso_user_registration] = false
+    AppConfig[:oauth_allow_user_registration] = false
     oauth = ASOauth.new(provider: "saml")
     token = generate_login_token(username: "existinguser")
 
-    DB.stubs(:[]).returns(stub(filter: stub(count: 1)))
+    DB.stubs(:[]).returns(stub(where: stub(count: 1)))
 
     result = oauth.authenticate("existinguser", token)
 


### PR DESCRIPTION
- adds optional `AppConfig[:aspace_oauth_allow_sso_user_registration]` to prevent new user creation
- adds tests for same